### PR TITLE
Typo to fix inconsistency with $

### DIFF
--- a/spice.md
+++ b/spice.md
@@ -18,7 +18,7 @@ volare enable --pdk sky130 0fe599b2afb6708d281543108caf8310912f54af
 ```
 You should now see the PDK installed:
 ```bash
-$ ls ~/.volare
+ls ~/.volare
 sky130A  sky130B  volare
 ```
 


### PR DESCRIPTION
All other calls in the command line such as git and pip don't have $ in front, thus to keep things consistent, it's best to remove the $ in front of ls ~/.volare. It likely came from copying the command from the Ubuntu terminal.