### PR TITLE
Typo to fix inconsistency with $

### DIFF
--- a/spice.md
+++ b/spice.md
@@ -18,7 +18,7 @@ volare enable --pdk sky130 0fe599b2afb6708d281543108caf8310912f54af
 ```
 You should now see the PDK installed:
 ```bash
-$ ls ~/.volare
+ls ~/.volare
 sky130A  sky130B  volare
 ```
 


### PR DESCRIPTION
Using calls in the command such as pip, and git, however not including $, seems to be the standard, thus fixing this little typo that probably came from grabbing the command used in the Linux terminal.